### PR TITLE
feat: log all ingame ticket events to a configurable thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
         "express": "^4.19.2",
         "node-steam-openid": "^1.2.3",
         "pg": "^8.12.0"
-    }
+    },
+    "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/src/interactions/tickets/close.ts
+++ b/src/interactions/tickets/close.ts
@@ -132,32 +132,28 @@ export default {
         if (!logChannel || !logChannel.isTextBased()) return;
 
         // @NotKeira - Start
-        // --- Ticket type thread logging ---
-        let threadName = "General";
-        if (ticketChannel.metadata && ticketChannel.metadata.reason) {
-            threadName = ticketChannel.metadata.reason;
-        }
+        // --- Ingame ticket thread logging ---
         let thread;
         if (
             logChannel.type === ChannelType.GuildText ||
             logChannel.type === ChannelType.GuildAnnouncement
         ) {
-            // @ts-ignore
-            thread = logChannel.threads.cache.find(
-                (t) => t.name === threadName && !t.archived,
-            );
+            // Try to find thread by ID or name from config
+            thread =
+                logChannel.threads.cache.get(server.ingame_ticket_thread!) ||
+                logChannel.threads.cache.find(
+                    (t) =>
+                        t.name === server.ingame_ticket_thread && !t.archived,
+                );
             if (!thread) {
-                // @ts-ignore
                 thread = await logChannel.threads.create({
-                    name: threadName,
-                    autoArchiveDuration: 1440, // 24 * 60 mins btw
-                    reason: `Ticket logs for type: ${threadName}`,
+                    name: server.ingame_ticket_thread || "Ingame SCP Tickets",
+                    autoArchiveDuration: 1440,
+                    reason: `Ticket logs for ingame tickets`,
                 });
             }
         }
-        // @NotKeira - End
-        // --- End of the thread logic shit ---
-
+        // --- End thread logic ---
         const embed = embed_()
             .setTitle(serverLocale.get((lang) => lang.close.embeds.title))
             .setDescription(

--- a/src/interactions/tickets/close.ts
+++ b/src/interactions/tickets/close.ts
@@ -1,4 +1,9 @@
-import { AttachmentBuilder, GuildMemberRoleManager, TextChannel } from "discord.js";
+import {
+    AttachmentBuilder,
+    GuildMemberRoleManager,
+    TextChannel,
+    ChannelType,
+} from "discord.js";
 import { Command } from "../../types/discord";
 import { db, getLocale, getServer } from "../../db";
 import { tickets } from "../../schema";
@@ -6,7 +11,8 @@ import { eq } from "drizzle-orm";
 import {
     DiscordFetch,
     embed as embed_,
-    fetchChannel, hasModRole
+    fetchChannel,
+    hasModRole,
 } from "../../utils/discord";
 import { Locales, replacement } from "../../locales";
 
@@ -124,6 +130,34 @@ export default {
             server.log_channel,
         );
         if (!logChannel || !logChannel.isTextBased()) return;
+
+        // @NotKeira - Start
+        // --- Ticket type thread logging ---
+        let threadName = "General";
+        if (ticketChannel.metadata && ticketChannel.metadata.reason) {
+            threadName = ticketChannel.metadata.reason;
+        }
+        let thread;
+        if (
+            logChannel.type === ChannelType.GuildText ||
+            logChannel.type === ChannelType.GuildAnnouncement
+        ) {
+            // @ts-ignore
+            thread = logChannel.threads.cache.find(
+                (t) => t.name === threadName && !t.archived,
+            );
+            if (!thread) {
+                // @ts-ignore
+                thread = await logChannel.threads.create({
+                    name: threadName,
+                    autoArchiveDuration: 1440, // 24 * 60 mins btw
+                    reason: `Ticket logs for type: ${threadName}`,
+                });
+            }
+        }
+        // @NotKeira - End
+        // --- End of the thread logic shit ---
+
         const embed = embed_()
             .setTitle(serverLocale.get((lang) => lang.close.embeds.title))
             .setDescription(
@@ -177,7 +211,14 @@ export default {
                     value: `\`${ticketChannel.metadata.serverName}\``,
                 },
             );
-        await logChannel.send({ embeds: [embed], files: [attachment] });
+        if (thread) {
+            await thread.send({ embeds: [embed], files: [attachment] });
+        } else if (
+            logChannel.type === ChannelType.GuildText ||
+            logChannel.type === ChannelType.GuildAnnouncement
+        ) {
+            await logChannel.send({ embeds: [embed], files: [attachment] });
+        }
     },
 } satisfies Command;
 

--- a/src/interactions/tickets/delete.ts
+++ b/src/interactions/tickets/delete.ts
@@ -72,32 +72,28 @@ export default {
                       ),
             );
         // @NotKeira - Start
-        // --- Ticket type thread logging ---
-        let threadName = "General";
-        if (ticketChannel.metadata && ticketChannel.metadata.reason) {
-            threadName = ticketChannel.metadata.reason;
-        }
+        // --- Ingame ticket thread logging ---
         let thread;
         if (
             logChannel.type === ChannelType.GuildText ||
             logChannel.type === ChannelType.GuildAnnouncement
         ) {
-            // @ts-ignore
-            thread = logChannel.threads.cache.find(
-                (t) => t.name === threadName && !t.archived,
-            );
+            // Try to find thread by ID or name from config
+            thread =
+                logChannel.threads.cache.get(server.ingame_ticket_thread!) ||
+                logChannel.threads.cache.find(
+                    (t) =>
+                        t.name === server.ingame_ticket_thread && !t.archived,
+                );
             if (!thread) {
-                // @ts-ignore
                 thread = await logChannel.threads.create({
-                    name: threadName,
-                    autoArchiveDuration: 1440, // 24 * 60 minutes
-                    reason: `Ticket logs for type: ${threadName}`,
+                    name: server.ingame_ticket_thread || "Ingame SCP Tickets",
+                    autoArchiveDuration: 1440,
+                    reason: `Ticket logs for ingame tickets`,
                 });
             }
         }
-        // @NotKeira - End
-        // --- End of thread logic shit ---
-
+        // --- End thread logic ---
         if (thread) {
             await thread.send({ embeds: [embed] });
         } else if (

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,12 @@
-import { boolean, pgTable, serial, text, uuid, integer, jsonb } from "drizzle-orm/pg-core";
+import {
+    boolean,
+    pgTable,
+    serial,
+    text,
+    uuid,
+    integer,
+    jsonb,
+} from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
 export type Languages = "en" | null;
@@ -20,13 +28,14 @@ export const servers = pgTable("servers", {
     locale: text("locale").$type<Languages>(),
     token: text("token").unique(),
     lastTicketNo: integer("lastTicketNo").notNull().default(0),
+    ingame_ticket_thread: text("ingame_ticket_thread"),
 });
 
 export type TicketMetadata = {
     reason: string;
     reported: string;
     serverName: string;
-}
+};
 
 export const tickets = pgTable("tickets", {
     id: serial("id").primaryKey(),
@@ -40,6 +49,5 @@ export const tickets = pgTable("tickets", {
         .default(sql`'{}'::text[]`),
     channelId: text("channelId").unique(),
     closed: boolean("closed").notNull().default(false),
-    metadata: jsonb("metadata").$type<TicketMetadata>()
+    metadata: jsonb("metadata").$type<TicketMetadata>(),
 });
-


### PR DESCRIPTION
This PR updates the ticket logging system so that all ingame tickets created via Friday are logged to a single, configurable thread in the log channel. The thread is specified by the new [ingame_ticket_thread](https://github.com/NotKeira/Friday/blob/61514b61eccffe96aeedfc6c8bc6d0c63ef0a290/src/schema.ts#L31) config option in the servers table. If the thread does not exist, it will be created automatically.

Removes previous logic that routed logs based on ticket metadata.
Ensures all ingame ticket logs are organized in one place for easier moderation and review.
Includes schema and logic updates for the new config option.